### PR TITLE
Add Evento JPA entity

### DIFF
--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Espacio.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Espacio.java
@@ -1,0 +1,15 @@
+package edu.unla.gestion_eventos.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Espacio {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	private String nombre;
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/EstadoEvento.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/EstadoEvento.java
@@ -1,0 +1,7 @@
+package edu.unla.gestion_eventos.model;
+
+public enum EstadoEvento {
+SOLICITADO,
+APROBADO,
+RECHAZADO
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Evento.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Evento.java
@@ -1,0 +1,36 @@
+package edu.unla.gestion_eventos.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Evento {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	private String nombre;
+	private LocalDateTime fechaInicio;
+	private LocalDateTime fechaFin;
+	
+	@Enumerated(EnumType.STRING)
+	private EstadoEvento estado;
+	
+	@ManyToOne
+	private Usuario solicitante;
+	
+	@ManyToOne
+	private Espacio espacio;
+	
+	@ManyToMany
+	private List<Recurso> recursos;
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Recurso.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Recurso.java
@@ -1,0 +1,15 @@
+package edu.unla.gestion_eventos.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Recurso {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	private String nombre;
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Usuario.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Usuario.java
@@ -1,0 +1,15 @@
+package edu.unla.gestion_eventos.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Usuario {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	private String nombre;
+}


### PR DESCRIPTION
## Summary
- add EstadoEvento enum
- create Evento entity with relations to Usuario, Espacio and Recurso
- add basic Usuario, Espacio and Recurso entities for references

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686db8979edc832996a78b46ac0e2d7e