### PR TITLE
Add Usuario CRUD

### DIFF
--- a/backend/src/main/java/edu/unla/gestion_eventos/controller/UsuarioController.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/controller/UsuarioController.java
@@ -1,0 +1,53 @@
+package edu.unla.gestion_eventos.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.unla.gestion_eventos.model.Usuario;
+import edu.unla.gestion_eventos.service.UsuarioService;
+
+@RestController
+@RequestMapping("/api/usuarios")
+public class UsuarioController {
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @PostMapping
+    public ResponseEntity<Usuario> crear(@RequestBody Usuario usuario) {
+        return ResponseEntity.ok(usuarioService.crear(usuario));
+    }
+
+    @GetMapping
+    public List<Usuario> listar() {
+        return usuarioService.listar();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Usuario> obtener(@PathVariable Long id) {
+        return usuarioService.buscarPorId(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Usuario> actualizar(@PathVariable Long id, @RequestBody Usuario usuario) {
+        return ResponseEntity.ok(usuarioService.actualizar(id, usuario));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        usuarioService.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/RolUsuario.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/RolUsuario.java
@@ -1,0 +1,7 @@
+package edu.unla.gestion_eventos.model;
+
+public enum RolUsuario {
+    SOLICITANTE,
+    TECNICO,
+    ADMIN_CEREMONIAL
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Usuario.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Usuario.java
@@ -4,12 +4,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+import lombok.Data;
 
 @Entity
+@Data
 public class Usuario {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	
-	private String nombre;
+        private String nombre;
+        private String email;
+
+        @Enumerated(EnumType.STRING)
+        private RolUsuario rol;
+
+        private String departamento;
 }

--- a/backend/src/main/java/edu/unla/gestion_eventos/repository/UsuarioRepository.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/repository/UsuarioRepository.java
@@ -1,0 +1,11 @@
+package edu.unla.gestion_eventos.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.unla.gestion_eventos.model.Usuario;
+
+@Repository
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+    Usuario findByEmail(String email);
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/service/UsuarioService.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/service/UsuarioService.java
@@ -1,0 +1,41 @@
+package edu.unla.gestion_eventos.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.unla.gestion_eventos.model.Usuario;
+import edu.unla.gestion_eventos.repository.UsuarioRepository;
+
+@Service
+public class UsuarioService {
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    public Usuario crear(Usuario usuario) {
+        return usuarioRepository.save(usuario);
+    }
+
+    public List<Usuario> listar() {
+        return usuarioRepository.findAll();
+    }
+
+    public Optional<Usuario> buscarPorId(Long id) {
+        return usuarioRepository.findById(id);
+    }
+
+    public void eliminar(Long id) {
+        usuarioRepository.deleteById(id);
+    }
+
+    public Usuario actualizar(Long id, Usuario usuarioActualizado) {
+        Usuario usuario = usuarioRepository.findById(id).orElseThrow();
+        usuario.setNombre(usuarioActualizado.getNombre());
+        usuario.setEmail(usuarioActualizado.getEmail());
+        usuario.setRol(usuarioActualizado.getRol());
+        usuario.setDepartamento(usuarioActualizado.getDepartamento());
+        return usuarioRepository.save(usuario);
+    }
+}


### PR DESCRIPTION
## Summary
- expand `Usuario` entity with email, role and department fields
- create `RolUsuario` enum
- implement `UsuarioRepository`
- add `UsuarioService`
- add `UsuarioController`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686dc442af648329a35f075b3a6cf14e