### PR TITLE
Add Departamento entity and CRUD components

### DIFF
--- a/backend/src/main/java/edu/unla/gestion_eventos/controller/DepartamentoController.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/controller/DepartamentoController.java
@@ -1,0 +1,55 @@
+package edu.unla.gestion_eventos.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.unla.gestion_eventos.model.Departamento;
+import edu.unla.gestion_eventos.service.DepartamentoService;
+
+@RestController
+@RequestMapping("/api/departamentos")
+public class DepartamentoController {
+
+    private final DepartamentoService departamentoService;
+
+    public DepartamentoController(DepartamentoService departamentoService) {
+        this.departamentoService = departamentoService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Departamento> crear(@RequestBody Departamento departamento) {
+        return ResponseEntity.ok(departamentoService.crear(departamento));
+    }
+
+    @GetMapping
+    public List<Departamento> listar() {
+        return departamentoService.listar();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Departamento> obtener(@PathVariable Long id) {
+        return departamentoService.buscarPorId(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Departamento> actualizar(@PathVariable Long id, @RequestBody Departamento departamento) {
+        return ResponseEntity.ok(departamentoService.actualizar(id, departamento));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        departamentoService.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Departamento.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Departamento.java
@@ -1,0 +1,29 @@
+package edu.unla.gestion_eventos.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Departamento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nombre;
+
+    private String colorVisual; // Por ejemplo: "#FF0000" para distinguir en el calendario
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/repository/DepartamentoRepository.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/repository/DepartamentoRepository.java
@@ -1,0 +1,9 @@
+package edu.unla.gestion_eventos.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import edu.unla.gestion_eventos.model.Departamento;
+
+public interface DepartamentoRepository extends JpaRepository<Departamento, Long> {
+    Departamento findByNombre(String nombre);
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/service/DepartamentoService.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/service/DepartamentoService.java
@@ -1,0 +1,42 @@
+package edu.unla.gestion_eventos.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import edu.unla.gestion_eventos.model.Departamento;
+import edu.unla.gestion_eventos.repository.DepartamentoRepository;
+
+@Service
+public class DepartamentoService {
+
+    private final DepartamentoRepository departamentoRepository;
+
+    public DepartamentoService(DepartamentoRepository departamentoRepository) {
+        this.departamentoRepository = departamentoRepository;
+    }
+
+    public Departamento crear(Departamento departamento) {
+        return departamentoRepository.save(departamento);
+    }
+
+    public List<Departamento> listar() {
+        return departamentoRepository.findAll();
+    }
+
+    public Optional<Departamento> buscarPorId(Long id) {
+        return departamentoRepository.findById(id);
+    }
+
+    public Departamento actualizar(Long id, Departamento actualizado) {
+        Departamento dpto = departamentoRepository.findById(id).orElseThrow();
+        dpto.setNombre(actualizado.getNombre());
+        dpto.setColorVisual(actualizado.getColorVisual());
+        return departamentoRepository.save(dpto);
+    }
+
+    public void eliminar(Long id) {
+        departamentoRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Departamento` entity with Lombok annotations
- create `DepartamentoRepository`
- implement `DepartamentoService` for CRUD logic
- expose REST API via `DepartamentoController`

## Testing
- `bash ./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686dc63edad883299ac3083f70ab9253