### PR TITLE
Add Recurso entity and endpoints

### DIFF
--- a/backend/src/main/java/edu/unla/gestion_eventos/controller/RecursoController.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/controller/RecursoController.java
@@ -1,0 +1,66 @@
+package edu.unla.gestion_eventos.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.unla.gestion_eventos.model.Recurso;
+import edu.unla.gestion_eventos.model.TipoRecurso;
+import edu.unla.gestion_eventos.service.RecursoService;
+
+@RestController
+@RequestMapping("/api/recursos")
+public class RecursoController {
+
+    private final RecursoService recursoService;
+
+    public RecursoController(RecursoService recursoService) {
+        this.recursoService = recursoService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Recurso> crear(@RequestBody Recurso recurso) {
+        return ResponseEntity.ok(recursoService.crear(recurso));
+    }
+
+    @GetMapping
+    public List<Recurso> listar() {
+        return recursoService.listar();
+    }
+
+    @GetMapping("/disponibles")
+    public List<Recurso> listarDisponibles() {
+        return recursoService.listarDisponibles();
+    }
+
+    @GetMapping("/tipo/{tipo}")
+    public List<Recurso> buscarPorTipo(@PathVariable TipoRecurso tipo) {
+        return recursoService.buscarPorTipo(tipo);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Recurso> obtener(@PathVariable Long id) {
+        return recursoService.buscarPorId(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Recurso> actualizar(@PathVariable Long id, @RequestBody Recurso recurso) {
+        return ResponseEntity.ok(recursoService.actualizar(id, recurso));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        recursoService.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/Recurso.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/Recurso.java
@@ -1,15 +1,33 @@
 package edu.unla.gestion_eventos.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Recurso {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-	
-	private String nombre;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nombre;
+
+    @Enumerated(EnumType.STRING)
+    private TipoRecurso tipo;
+
+    private Boolean disponible;
 }

--- a/backend/src/main/java/edu/unla/gestion_eventos/model/TipoRecurso.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/model/TipoRecurso.java
@@ -1,0 +1,10 @@
+package edu.unla.gestion_eventos.model;
+
+public enum TipoRecurso {
+    AUDIO,
+    VIDEO,
+    PERSONAL,
+    ILUMINACION,
+    ESCENARIO,
+    OTRO
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/repository/RecursoRepository.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/repository/RecursoRepository.java
@@ -1,0 +1,13 @@
+package edu.unla.gestion_eventos.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import edu.unla.gestion_eventos.model.Recurso;
+import edu.unla.gestion_eventos.model.TipoRecurso;
+
+public interface RecursoRepository extends JpaRepository<Recurso, Long> {
+    List<Recurso> findByDisponibleTrue();
+    List<Recurso> findByTipo(TipoRecurso tipo);
+}

--- a/backend/src/main/java/edu/unla/gestion_eventos/service/RecursoService.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/service/RecursoService.java
@@ -1,0 +1,52 @@
+package edu.unla.gestion_eventos.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import edu.unla.gestion_eventos.model.Recurso;
+import edu.unla.gestion_eventos.model.TipoRecurso;
+import edu.unla.gestion_eventos.repository.RecursoRepository;
+
+@Service
+public class RecursoService {
+
+    private final RecursoRepository recursoRepository;
+
+    public RecursoService(RecursoRepository recursoRepository) {
+        this.recursoRepository = recursoRepository;
+    }
+
+    public Recurso crear(Recurso recurso) {
+        return recursoRepository.save(recurso);
+    }
+
+    public List<Recurso> listar() {
+        return recursoRepository.findAll();
+    }
+
+    public Optional<Recurso> buscarPorId(Long id) {
+        return recursoRepository.findById(id);
+    }
+
+    public Recurso actualizar(Long id, Recurso actualizado) {
+        Recurso recurso = recursoRepository.findById(id).orElseThrow();
+        recurso.setNombre(actualizado.getNombre());
+        recurso.setTipo(actualizado.getTipo());
+        recurso.setDisponible(actualizado.getDisponible());
+        return recursoRepository.save(recurso);
+    }
+
+    public void eliminar(Long id) {
+        recursoRepository.deleteById(id);
+    }
+
+    public List<Recurso> listarDisponibles() {
+        return recursoRepository.findByDisponibleTrue();
+    }
+
+    public List<Recurso> buscarPorTipo(TipoRecurso tipo) {
+        return recursoRepository.findByTipo(tipo);
+    }
+}


### PR DESCRIPTION
## Summary
- expand `Recurso` entity with fields and Lombok annotations
- add `TipoRecurso` enum
- implement repository, service, and controller for `Recurso`

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686dc8ca8d448329957c2ccf6f32d6de