### PR TITLE
Agregar dependencia MySQL

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -38,16 +38,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>8.4.0</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>


### PR DESCRIPTION
## Summary
- agregar la dependencia `mysql-connector-j` en el `pom.xml`

## Testing
- `./mvnw -q test` *(falló: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ddc5164108329aa1f0b34684d218c