### PR TITLE
Fix column name for department colors

### DIFF
--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,7 +1,7 @@
 -- DEPARTAMENTOS
-INSERT INTO departamento (nombre, color_visual) VALUES ('Humanidades y Artes', '#FF5733');
-INSERT INTO departamento (nombre, color_visual) VALUES ('Desarrollo Productivo Tecnologico', '#33FF57');
-INSERT INTO departamento (nombre, color_visual) VALUES ('Salud Comunitaria', '#3357FF');
+INSERT INTO departamento (nombre, colorVisual) VALUES ('Humanidades y Artes', '#FF5733');
+INSERT INTO departamento (nombre, colorVisual) VALUES ('Desarrollo Productivo Tecnologico', '#33FF57');
+INSERT INTO departamento (nombre, colorVisual) VALUES ('Salud Comunitaria', '#3357FF');
 
 -- USUARIOS
 INSERT INTO usuario (nombre, email, rol, departamento_id)


### PR DESCRIPTION
## Summary
- update `data.sql` to use `colorVisual` instead of `color_visual` when inserting departments

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686deefa82708329be0694c1f3d71bd8