### PR TITLE
Add deferred datasource initialization property

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,5 +7,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.defer-datasource-initialization=true
 
 spring.sql.init.mode=always


### PR DESCRIPTION
## Summary
- allow deferred datasource initialization for JPA

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686df5f104e88329813f424f520fe5a9