### PR TITLE
Disable spring security for dev

### DIFF
--- a/backend/src/main/java/edu/unla/gestion_eventos/config/SeguridadConfig.java
+++ b/backend/src/main/java/edu/unla/gestion_eventos/config/SeguridadConfig.java
@@ -1,0 +1,21 @@
+package edu.unla.gestion_eventos.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SeguridadConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Summary
- configure SeguridadConfig to disable CSRF and permit all requests for development

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df8285e488329ab03ab10a34d0e2c